### PR TITLE
Install Type pannel change

### DIFF
--- a/resources/dashboards/sbr-etcd-by-cluster-id.configmap.yaml
+++ b/resources/dashboards/sbr-etcd-by-cluster-id.configmap.yaml
@@ -179,7 +179,7 @@ data:
               },
               "editorMode": "builder",
               "exemplar": false,
-              "expr": "label_replace(label_replace(cluster_installer{_id=\"$cluster_id\"}, \"type\", \"Others\", \"type\", \"other\"), \"type\", \"IPI\", \"type\", \"openshift-install\")",
+              "expr": "label_replace(label_replace(cluster_installer{_id=\"$cluster_id\", type!=\"\"}, \"type\", \"Others\", \"type\", \"other\"), \"type\", \"IPI\", \"type\", \"openshift-install\") or label_replace(cluster_installer{_id=\"$cluster_id\"} unless on(_id) cluster_installer{_id=\"$cluster_id\", type!=\"\"}, \"type\", \"Unknown\", \"_id\", \".+\")",
               "format": "time_series",
               "instant": true,
               "intervalFactor": 1,


### PR DESCRIPTION
Found some cluster which is missing the "Type" field (probably old cluster) which break this panel, to fix it as been added an "or" option in case that field is missing it and declaring it as "Unknown". Same as Insight is doing it.