### PR TITLE
Fix error output for alertmanager and jsonnet

### DIFF
--- a/magefiles/dashboards.go
+++ b/magefiles/dashboards.go
@@ -27,7 +27,7 @@ func (d Dashboards) Alertmanager() error {
 	vm := getVM()
 	j, err := vm.EvaluateFile(getDashboardFile(filename))
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to evaluate jsonnset: %w", err)
 	}
 
 	err = writeDashboardFile(fileOut, j)

--- a/magefiles/update.go
+++ b/magefiles/update.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 )
@@ -14,7 +15,7 @@ type (
 func (Update) Alertmanager() error {
 	err := sh.Run("jb", "update", "github.com/prometheus/alertmanager/doc/alertmanager-mixin@main", `--jsonnetpkg-home=vendor_jsonnet`)
 	if err != nil {
-		fmt.Errorf("failed to update alertmanager mixin: %w", err)
+		return fmt.Errorf("failed to update alertmanager mixin: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
This is a drive-by change from creating the configuration for the Loki dashboards. I did not want to mix it in with the dashboards itself.